### PR TITLE
Fix checkmark bug + Some minor trick improvements

### DIFF
--- a/src/gfx.c
+++ b/src/gfx.c
@@ -225,8 +225,8 @@ struct gfx_texture *gfx_texldr_load(struct gfx_texldr *texldr,
   texture->tile_height = texdesc->tile_height;
   texture->tiles_x = texdesc->tiles_x;
   texture->tiles_y = texdesc->tiles_y;
-  texture->tile_size = ((texture->tile_width * texture->tile_height *
-                         G_SIZ_BITS(texture->im_siz) + 7) / 8 + 63) / 64 * 64;
+  texture->tile_size = (texture->tile_width * texture->tile_height *
+                         G_SIZ_BITS(texture->im_siz) + 63) / 64 * 8;
   size_t texture_size = texture->tile_size *
                         texture->tiles_x * texture->tiles_y;
   void *texture_data = NULL;
@@ -279,8 +279,8 @@ struct gfx_texture *gfx_texture_create(g_ifmt_t im_fmt, g_isiz_t im_siz,
   struct gfx_texture *texture = malloc(sizeof(*texture));
   if (!texture)
     return texture;
-  texture->tile_size = ((tile_width * tile_height *
-                         G_SIZ_BITS(im_siz) + 7) / 8 + 63) / 64 * 64;
+  texture->tile_size = (tile_width * tile_height *
+                         G_SIZ_BITS(im_siz) + 63) / 64 * 8;
   texture->data = memalign(64, tiles_x * tiles_y * texture->tile_size);
   if (!texture->data) {
     free(texture);

--- a/src/tricks.c
+++ b/src/tricks.c
@@ -388,6 +388,7 @@ void load_lava_piranha_skip() {
 
 void load_ch5_card_lzs() {
     STORY_PROGRESS = 0x23;
+    fp_set_global_flag(0x51e, 1); //piranha plant cutscene
     fp_warp(0x12, 0xd, 1);
 }
 

--- a/src/tricks.c
+++ b/src/tricks.c
@@ -14,6 +14,14 @@ int equip_badge (int16_t badgeID) {
     return -1;
 }
 
+void unequip_badge (int16_t badgeID) {
+    for (int i = 0; i < 64; i++) {
+        if (pm_player.player_data.equipped_badges[i] == badgeID) {
+            pm_player.player_data.equipped_badges[i] = 0;
+        }
+    }
+}
+
 int find_badge (int16_t badgeID) { //return 0 if badgeID not found, badgeID returned if found
     for (int i = 0; i < 128; i++) {
         if (pm_player.player_data.badges[i] == badgeID) {
@@ -30,6 +38,14 @@ int find_equipped_badge (int16_t badgeID) { //return 0 if badgeID not found, bad
         }
     }
     return 0;
+}
+
+void remove_badge (int16_t badgeID) {
+    for (int i = 0; i < 128; i++) {
+        if (pm_player.player_data.badges[i] == badgeID) {
+            pm_player.player_data.badges[i] = 0;
+        }
+    }
 }
 
 void check_for_hammer() {
@@ -439,6 +455,10 @@ void load_sushie_glitch() {
 void load_ice_staircase_skip() {
     set_partner(LAKILESTER);
     STORY_PROGRESS = 0x4b;
+    fp_set_global_flag(0x5b7, 0); //mega jump block
+    int16_t megaJump = 0x123;
+    unequip_badge(megaJump);
+    remove_badge(megaJump);
     fp_warp(0x14, 9, 0);
 }
 


### PR DESCRIPTION
- Fixes glitch with checkmark icon displaying incorrectly
- Add badge related functions to tricks.c
- Reset mega jump block and remove mega jump for iss
- Set piranha plant cutscene flag for ch5 card lzs