### PR TITLE
Fix warp crashes and add PRINTF

### DIFF
--- a/makefile
+++ b/makefile
@@ -79,6 +79,7 @@ $$(OUTDIR-$(1))   :
 	mkdir -p $$@
 patch-$(1)        : $$(BIN-$(1))
 	$(ARMIPS) $$(BUILDFILE-$(1))
+	@find ./rom/ -name "fp-*.z64" -type f -printf "$(GRU) $(LUAFILE) %f\n" -exec $(GRU) $(LUAFILE) {} \;
 endef
 
 $(foreach v,$(FP_VERSIONS),$(eval $(call bin_template,fp-$(v),$(v),fp)))

--- a/makefile
+++ b/makefile
@@ -17,11 +17,17 @@ CFILES      = *.c
 SFILES      = *.s
 FP_VERSIONS = PM64J PM64U
 NAME        = fp
+NDEBUG     ?= 0
 
 ADDRESS     = 0x80400040
 CFLAGS      = -c -MMD -MP -std=gnu11 -Wall -ffunction-sections -fdata-sections -O1 -fno-reorder-blocks 
 CPPFLAGS    = -DPACKAGE=$(PACKAGE) -DURL=$(URL) -DF3DEX_GBI_2
 LDFLAGS     = -T gl-n64.ld -nostartfiles -specs=nosys.specs -Wl,--gc-sections -Wl,--defsym,start=$(ADDRESS) 
+
+ifeq ($(NDEBUG),1)
+  CFLAGS += -DNDEBUG
+  CPPFLAGS += -DNDEBUG
+endif
 
 FP          = $(foreach v,$(FP_VERSIONS),patch-fp-$(v))
 FP-PM64U    = patch-fp-PM64U

--- a/src/commands.c
+++ b/src/commands.c
@@ -94,12 +94,19 @@ _Bool fp_warp(uint16_t group, uint16_t room, uint16_t entrance) {
     pm_unk2.room_change_state = 1;
 
     PRINTF("***** WARP TRIGGERED ******\n");
-    PRINTF("pm_popup_menu_var: %d (addr:%8X) \n", pm_popup_menu_var, &pm_popup_menu_var);
-    // if a popup menu is open, hide it and wait
-    if (pm_popup_menu_var == 1) {
-        PRINTF("popup is open, setting delay and hiding menu\n");
-        fp.warp_delay = 15;
-        pm_HidePopupMenu();
+
+    if (pm_battle_state_2 == 0) {
+        if (pm_popup_menu_var == 1) {
+            PRINTF("overworld popup is open, setting delay and hiding menu\n");
+            fp.warp_delay = 15;
+            pm_HidePopupMenu();
+        }
+    } else if (pm_battle_state_2 == 0xC9) {
+        PRINTF("battle popup is open, destroying menu\n");
+        pm_func_802A472C();
+        fp.warp_delay = 0;
+    } else {
+        fp.warp_delay = 0;
     }
 
     fp.warp = 1;

--- a/src/commands.c
+++ b/src/commands.c
@@ -80,10 +80,10 @@ _Bool fp_warp_will_crash() {
 
 _Bool fp_warp(uint16_t group, uint16_t room, uint16_t entrance) {
     //this should prevent most warp crashes, but eventually it'd be ideal to figure out how to prevent crashes entirely
-    if (fp_warp_will_crash()) {
-        fp_log("can't warp right now");
-        return 0;
-    }
+    // if (fp_warp_will_crash()) {
+    //     fp_log("can't warp right now");
+    //     return 0;
+    // }
 
     pm_PlayAmbientSounds(-1, 0);
     pm_status.loading_zone_tangent = 0;
@@ -93,8 +93,16 @@ _Bool fp_warp(uint16_t group, uint16_t room, uint16_t entrance) {
 
     pm_unk2.room_change_state = 1;
 
-    uint32_t val = RM_CHNGE_PTR;
-    pm_warp.room_change_ptr = val;
+    PRINTF("***** WARP TRIGGERED ******\n");
+    PRINTF("pm_popup_menu_var: %d (addr:%8X) \n", pm_popup_menu_var, &pm_popup_menu_var);
+    // if a popup menu is open, hide it and wait
+    if (pm_popup_menu_var == 1) {
+        PRINTF("popup is open, setting delay and hiding menu\n");
+        fp.warp_delay = 15;
+        pm_HidePopupMenu();
+    }
+
+    fp.warp = 1;
 
     return 1;
 }

--- a/src/commands.c
+++ b/src/commands.c
@@ -95,19 +95,27 @@ _Bool fp_warp(uint16_t group, uint16_t room, uint16_t entrance) {
 
     PRINTF("***** WARP TRIGGERED ******\n");
 
-    if (pm_battle_state_2 == 0) {
+    if (pm_status.is_battle) {
+        if (pm_battle_state_2 == 0xC9) {
+            PRINTF("battle popup is open, destroying menu\n");
+            pm_func_802A472C();
+        }
+        fp.warp_delay = 0;
+    } else {
         if (pm_popup_menu_var == 1) {
             PRINTF("overworld popup is open, setting delay and hiding menu\n");
             fp.warp_delay = 15;
             pm_HidePopupMenu();
+        } else {
+            fp.warp_delay = 0;
         }
-    } else if (pm_battle_state_2 == 0xC9) {
-        PRINTF("battle popup is open, destroying menu\n");
-        pm_func_802A472C();
-        fp.warp_delay = 0;
-    } else {
-        fp.warp_delay = 0;
     }
+
+    // set the global curtain to default+off state
+    // this is mainly to prevent a crash when warping from "card obtained"
+    pm_SetCurtainScaleGoal(2.0f);
+    pm_SetCurtainDrawCallback(NULL);
+    pm_SetCurtainFadeGoal(0.0f);
 
     fp.warp = 1;
 

--- a/src/fp.c
+++ b/src/fp.c
@@ -410,6 +410,27 @@ void fp_main(void) {
         }
     }
 
+    /* handle warps */
+
+    if (fp.warp_delay != 0) {
+        PRINTF("fp.warp_delay: %d\n", fp.warp_delay);
+    }
+
+    if (fp.warp_delay > 0) {
+        fp.warp_delay--;
+    }
+
+    if (fp.warp && fp.warp_delay == 0) {
+        // if a popup menu is currently hidden, destroy it
+        if (pm_popup_menu_var == 10) {
+            PRINTF("destroying popupmenu\n");
+            pm_DestroyPopupMenu();
+        }
+        PRINTF("changing game mode\n");
+        pm_SetGameMode(5); // start the "change map" game mode
+        fp.warp = 0;
+    }
+
     /* draw and animate menus */
     while (fp.menu_active && menu_think(fp.main_menu))
       ;
@@ -509,6 +530,8 @@ void init() {
     fp.lz_stored = 0;
     fp.player_landed = 0;
     fp.frames_since_land = 0;
+    fp.warp = 0;
+    fp.warp_delay = 0;
 
     /* initialize io device */
     io_init();

--- a/src/fp.c
+++ b/src/fp.c
@@ -424,7 +424,7 @@ void fp_main(void) {
             pm_DestroyPopupMenu();
         }
         
-        pm_SetMapTransitionEffect(8); // mario head transition
+        pm_SetMapTransitionEffect(0); // normal black fade
         PRINTF("changing game mode\n");
         pm_SetGameMode(5); // start the "change map" game mode
         fp.warp = 0;

--- a/src/fp.c
+++ b/src/fp.c
@@ -420,7 +420,7 @@ void fp_main(void) {
     if (fp.warp && fp.warp_delay == 0) {
         // if a popup menu is currently hidden, destroy it
         if (pm_popup_menu_var == 10) {
-            PRINTF("destroying popupmenu\n");
+            PRINTF("destroying popup menu\n");
             pm_DestroyPopupMenu();
         }
         

--- a/src/fp.c
+++ b/src/fp.c
@@ -423,6 +423,8 @@ void fp_main(void) {
             PRINTF("destroying popupmenu\n");
             pm_DestroyPopupMenu();
         }
+        
+        pm_SetMapTransitionEffect(8); // mario head transition
         PRINTF("changing game mode\n");
         pm_SetGameMode(5); // start the "change map" game mode
         fp.warp = 0;

--- a/src/fp.c
+++ b/src/fp.c
@@ -412,11 +412,8 @@ void fp_main(void) {
 
     /* handle warps */
 
-    if (fp.warp_delay != 0) {
-        PRINTF("fp.warp_delay: %d\n", fp.warp_delay);
-    }
-
     if (fp.warp_delay > 0) {
+        PRINTF("fp.warp_delay: %d\n", fp.warp_delay);
         fp.warp_delay--;
     }
 

--- a/src/fp.h
+++ b/src/fp.h
@@ -62,7 +62,8 @@ typedef struct{
     _Bool                   lz_stored;
     _Bool                   player_landed;
     uint16_t                frames_since_land;
-    
+    _Bool                   warp;
+    uint8_t                 warp_delay;
 } fp_ctxt_t;
 
 extern fp_ctxt_t fp;
@@ -83,5 +84,10 @@ struct menu *create_practice_menu();
 struct menu *create_debug_menu();
 struct menu *create_settings_menu();
 
+#ifdef NDEBUG
+#define PRINTF(...) ((void)0)
+#else
+#define PRINTF(...) (osSyncPrintf(__VA_ARGS__))
+#endif
 
 #endif

--- a/src/pm64.h
+++ b/src/pm64.h
@@ -852,6 +852,7 @@ typedef __OSEventState __osEventStateTab_t[];
 #define pm_effects_addr                     0x800B4398
 #define pm_save_data_addr                   0x800DACC0
 #define pm_battle_status_addr               0x800DC070
+#define pm_popup_menu_var_addr              0x8010D640
 #define pm_overworld_addr                   0x8010EBB0
 #define pm_hud_addr                         0x8010EF58
 #define pm_player_addr                      0x8010EFC8
@@ -873,6 +874,7 @@ typedef __OSEventState __osEventStateTab_t[];
 #define pm_effects_addr                     0x800B4378
 #define pm_save_data_addr                   0x800DACA0
 #define pm_battle_status_addr               0x800DC050
+#define pm_popup_menu_var_addr              0x8010D800
 #define pm_overworld_addr                   0x8010ED70
 #define pm_hud_addr                         0x8010F118
 #define pm_player_addr                      0x8010F188
@@ -896,6 +898,7 @@ typedef __OSEventState __osEventStateTab_t[];
 #define pm_effects            (*(effects_ctxt_t*)        pm_effects_addr)
 #define pm_save_data          (*(save_data_ctxt_t*)      pm_save_data_addr)
 #define pm_battle_status      (*(battle_status_ctxt_t*)  pm_battle_status_addr)
+#define pm_popup_menu_var     (*(int32_t*)               pm_popup_menu_var_addr)
 #define pm_overworld          (*(overworld_ctxt_t*)      pm_overworld_addr)
 #define pm_hud                (*(hud_ctxt_t*)            pm_hud_addr)
 #define pm_player             (*(player_ctxt_t*)         pm_player_addr)
@@ -906,6 +909,7 @@ typedef __OSEventState __osEventStateTab_t[];
 
 /* Function Addresses */
 #if PM64_VERSION==PM64U
+#define osSyncPrintf_addr                   0x80025CFC
 #define __osPiGetAccess_addr                0x800614A4
 #define __osPiRelAccess_addr                0x80061510
 #define osCreateMesgQueue_addr              0x80065580
@@ -915,13 +919,17 @@ typedef __OSEventState __osEventStateTab_t[];
 #define pm_FioDeserializeState_addr         0x8002B490
 #define pm_FioReadFlash_addr                0x8002B868
 #define pm_FioWriteFlash_addr               0x8002B948
+#define pm_SetGameMode_addr                 0x800334F0
 #define pm_RemoveEffect_addr                0x8005A450
 #define pm_AddBadge_addr                    0x800E773C
+#define pm_HidePopupMenu_addr               0x800F13B0
+#define pm_DestroyPopupMenu_addr            0x800F1538
 #define pm_GameUpdate_addr                  0x80112FC4
 #define pm_PlayAmbientSounds_addr           0x80147368
 #define pm_PlaySfx_addr                     0x80149CB4
 #define pm_SaveGame_addr                    0x802E11A0
 #elif PM64_VERSION==PM64J
+#define osSyncPrintf_addr                   0x80025CFC
 #define __osPiGetAccess_addr                0x80061474
 #define __osPiRelAccess_addr                0x800614E0
 #define osCreateMesgQueue_addr              0x80065550
@@ -931,23 +939,31 @@ typedef __OSEventState __osEventStateTab_t[];
 #define pm_FioDeserializeState_addr         0x8002B450
 #define pm_FioReadFlash_addr                0x8002B828
 #define pm_FioWriteFlash_addr               0x8002B908
+#define pm_SetGameMode_addr                 0x80033180
 #define pm_RemoveEffect_addr                0x8005A100
 #define pm_AddBadge_addr                    0x800E76DC
+#define pm_HidePopupMenu_addr               0x800F1340
+#define pm_DestroyPopupMenu_addr            0x800F14C8
 #define pm_GameUpdate_addr                  0x801181D4
 #define pm_PlayAmbientSounds_addr           0x8014C418
 #define pm_PlaySfx_addr                     0x8014ED64
 #define pm_SaveGame_addr                    0x802DC150
+
 #endif
 
 /* Function Prototypes */
+typedef void (*osSyncPrintf_t) (const char *fmt, ...);
 typedef void (*__osPiGetAccess_t) ();
 typedef void (*__osPiRelAccess_t) ();
 typedef void (*osCreateMesgQueue_t) (OSMesgQueue *queue, OSMesg *msg, int32_t unk);
-typedef void (*osRecvMesg_t) (OSMesgQueue *queue, OSMesg *msg, int32_t unk);
+typedef int32_t (*osRecvMesg_t) (OSMesgQueue *queue, OSMesg *msg, int32_t flag);
 typedef int32_t (*pm_FioValidateFileChecksum_t) (void *buffer);
 typedef _Bool (*pm_FioFetchSavedFileInfo_t) ();
 typedef void (*pm_FioDeserializeState_t) ();
 typedef void (*pm_AddBadge_t) (Badge badgeID);
+typedef void (*pm_HidePopupMenu_t) (void);
+typedef void (*pm_DestroyPopupMenu_t) (void);
+typedef void (*pm_SetGameMode_t) (int32_t mode);
 typedef void (*pm_RemoveEffect_t) (EffectInstance *effect);
 typedef void (*pm_FioReadFlash_t) (int32_t slot, void *buffer, uint32_t size);
 typedef void (*pm_FioWriteFlash_t) (int32_t slot, void *buffer, uint32_t size);
@@ -957,6 +973,7 @@ typedef void (*pm_PlayAmbientSounds_t) (int32_t sounds_id, int32_t fade_time);
 typedef void (*pm_SaveGame_t) ();
 
 /* Functions */
+#define osSyncPrintf                ((osSyncPrintf_t)                osSyncPrintf_addr)
 #define __osPiGetAccess             ((__osPiGetAccess_t)             __osPiGetAccess_addr)
 #define __osPiRelAccess             ((__osPiRelAccess_t)             __osPiRelAccess_addr)
 #define osCreateMesgQueue           ((osCreateMesgQueue_t)           osCreateMesgQueue_addr)
@@ -966,8 +983,11 @@ typedef void (*pm_SaveGame_t) ();
 #define pm_FioDeserializeState      ((pm_FioDeserializeState_t)      pm_FioDeserializeState_addr)
 #define pm_FioReadFlash             ((pm_FioReadFlash_t)             pm_FioReadFlash_addr)
 #define pm_FioWriteFlash            ((pm_FioWriteFlash_t)            pm_FioWriteFlash_addr)
+#define pm_SetGameMode              ((pm_SetGameMode_t)              pm_SetGameMode_addr)
 #define pm_RemoveEffect             ((pm_RemoveEffect_t)             pm_RemoveEffect_addr)
 #define pm_AddBadge                 ((pm_AddBadge_t)                 pm_AddBadge_addr)
+#define pm_HidePopupMenu            ((pm_HidePopupMenu_t)            pm_HidePopupMenu_addr)
+#define pm_DestroyPopupMenu         ((pm_DestroyPopupMenu_t)         pm_DestroyPopupMenu_addr)
 #define pm_GameUpdate               ((pm_GameUpdate_t)               pm_GameUpdate_addr)
 #define pm_PlayAmbientSounds        ((pm_PlayAmbientSounds_t)        pm_PlayAmbientSounds_addr)
 #define pm_PlaySfx                  ((pm_PlaySfx_t)                  pm_PlaySfx_addr)

--- a/src/pm64.h
+++ b/src/pm64.h
@@ -925,6 +925,7 @@ typedef __OSEventState __osEventStateTab_t[];
 #define pm_HidePopupMenu_addr               0x800F13B0
 #define pm_DestroyPopupMenu_addr            0x800F1538
 #define pm_GameUpdate_addr                  0x80112FC4
+#define pm_SetMapTransitionEffect_addr      0x801382A0
 #define pm_PlayAmbientSounds_addr           0x80147368
 #define pm_PlaySfx_addr                     0x80149CB4
 #define pm_SaveGame_addr                    0x802E11A0
@@ -945,10 +946,10 @@ typedef __OSEventState __osEventStateTab_t[];
 #define pm_HidePopupMenu_addr               0x800F1340
 #define pm_DestroyPopupMenu_addr            0x800F14C8
 #define pm_GameUpdate_addr                  0x801181D4
+#define pm_SetMapTransitionEffect_addr      0x8013D350
 #define pm_PlayAmbientSounds_addr           0x8014C418
 #define pm_PlaySfx_addr                     0x8014ED64
 #define pm_SaveGame_addr                    0x802DC150
-
 #endif
 
 /* Function Prototypes */
@@ -968,6 +969,7 @@ typedef void (*pm_RemoveEffect_t) (EffectInstance *effect);
 typedef void (*pm_FioReadFlash_t) (int32_t slot, void *buffer, uint32_t size);
 typedef void (*pm_FioWriteFlash_t) (int32_t slot, void *buffer, uint32_t size);
 typedef void (*pm_GameUpdate_t) ();
+typedef int32_t (*pm_SetMapTransitionEffect_t) (int32_t transition);
 typedef void (*pm_PlaySfx_t) (int32_t sound_id);
 typedef void (*pm_PlayAmbientSounds_t) (int32_t sounds_id, int32_t fade_time);
 typedef void (*pm_SaveGame_t) ();
@@ -990,6 +992,7 @@ typedef void (*pm_SaveGame_t) ();
 #define pm_DestroyPopupMenu         ((pm_DestroyPopupMenu_t)         pm_DestroyPopupMenu_addr)
 #define pm_GameUpdate               ((pm_GameUpdate_t)               pm_GameUpdate_addr)
 #define pm_PlayAmbientSounds        ((pm_PlayAmbientSounds_t)        pm_PlayAmbientSounds_addr)
+#define pm_SetMapTransitionEffect   ((pm_SetMapTransitionEffect_t)   pm_SetMapTransitionEffect_addr)
 #define pm_PlaySfx                  ((pm_PlaySfx_t)                  pm_PlaySfx_addr)
 #define pm_SaveGame                 ((pm_SaveGame_t)                 pm_SaveGame_addr)
 

--- a/src/pm64.h
+++ b/src/pm64.h
@@ -851,8 +851,8 @@ typedef __OSEventState __osEventStateTab_t[];
 #define pm_enemy_flags_addr                 0x800B0FC0
 #define pm_effects_addr                     0x800B4398
 #define pm_save_data_addr                   0x800DACC0
-#define pm_battle_state_2_addr              0x800DC4DC
 #define pm_battle_status_addr               0x800DC070
+#define pm_battle_state_2_addr              0x800DC4DC
 #define pm_popup_menu_var_addr              0x8010D640
 #define pm_overworld_addr                   0x8010EBB0
 #define pm_hud_addr                         0x8010EF58
@@ -875,6 +875,7 @@ typedef __OSEventState __osEventStateTab_t[];
 #define pm_effects_addr                     0x800B4378
 #define pm_save_data_addr                   0x800DACA0
 #define pm_battle_status_addr               0x800DC050
+#define pm_battle_state_2_addr               0x800DC4BC
 #define pm_popup_menu_var_addr              0x8010D800
 #define pm_overworld_addr                   0x8010ED70
 #define pm_hud_addr                         0x8010F118
@@ -921,6 +922,9 @@ typedef __OSEventState __osEventStateTab_t[];
 #define pm_FioDeserializeState_addr         0x8002B490
 #define pm_FioReadFlash_addr                0x8002B868
 #define pm_FioWriteFlash_addr               0x8002B948
+#define pm_SetCurtainScaleGoal_addr         0x8002BEDC
+#define pm_SetCurtainDrawCallback_addr      0x8002BF04
+#define pm_SetCurtainFadeGoal_addr          0x8002BF14
 #define pm_SetGameMode_addr                 0x800334F0
 #define pm_RemoveEffect_addr                0x8005A450
 #define pm_AddBadge_addr                    0x800E773C
@@ -943,6 +947,9 @@ typedef __OSEventState __osEventStateTab_t[];
 #define pm_FioDeserializeState_addr         0x8002B450
 #define pm_FioReadFlash_addr                0x8002B828
 #define pm_FioWriteFlash_addr               0x8002B908
+#define pm_SetCurtainScaleGoal_addr         0x8002BE9C
+#define pm_SetCurtainDrawCallback_addr      0x8002BEC4
+#define pm_SetCurtainFadeGoal_addr          0x8002BED4
 #define pm_SetGameMode_addr                 0x80033180
 #define pm_RemoveEffect_addr                0x8005A100
 #define pm_AddBadge_addr                    0x800E76DC
@@ -953,6 +960,7 @@ typedef __OSEventState __osEventStateTab_t[];
 #define pm_PlayAmbientSounds_addr           0x8014C418
 #define pm_PlaySfx_addr                     0x8014ED64
 #define pm_SaveGame_addr                    0x802DC150
+#define pm_func_802A472C_addr               0x802A4608
 #endif
 
 /* Function Prototypes */
@@ -964,6 +972,9 @@ typedef int32_t (*osRecvMesg_t) (OSMesgQueue *queue, OSMesg *msg, int32_t flag);
 typedef int32_t (*pm_FioValidateFileChecksum_t) (void *buffer);
 typedef _Bool (*pm_FioFetchSavedFileInfo_t) ();
 typedef void (*pm_FioDeserializeState_t) ();
+typedef void (*pm_SetCurtainScaleGoal_t) (float goal);
+typedef void (*pm_SetCurtainDrawCallback_t) (void* callback);
+typedef void (*pm_SetCurtainFadeGoal_t) (float goal);
 typedef void (*pm_AddBadge_t) (Badge badgeID);
 typedef void (*pm_HidePopupMenu_t) (void);
 typedef void (*pm_DestroyPopupMenu_t) (void);
@@ -989,6 +1000,9 @@ typedef void (*pm_func_802A472C_t) ();
 #define pm_FioDeserializeState      ((pm_FioDeserializeState_t)      pm_FioDeserializeState_addr)
 #define pm_FioReadFlash             ((pm_FioReadFlash_t)             pm_FioReadFlash_addr)
 #define pm_FioWriteFlash            ((pm_FioWriteFlash_t)            pm_FioWriteFlash_addr)
+#define pm_SetCurtainScaleGoal      ((pm_SetCurtainScaleGoal_t)      pm_SetCurtainScaleGoal_addr)
+#define pm_SetCurtainDrawCallback   ((pm_SetCurtainDrawCallback_t)   pm_SetCurtainDrawCallback_addr)
+#define pm_SetCurtainFadeGoal       ((pm_SetCurtainFadeGoal_t)       pm_SetCurtainFadeGoal_addr)
 #define pm_SetGameMode              ((pm_SetGameMode_t)              pm_SetGameMode_addr)
 #define pm_RemoveEffect             ((pm_RemoveEffect_t)             pm_RemoveEffect_addr)
 #define pm_AddBadge                 ((pm_AddBadge_t)                 pm_AddBadge_addr)

--- a/src/pm64.h
+++ b/src/pm64.h
@@ -851,6 +851,7 @@ typedef __OSEventState __osEventStateTab_t[];
 #define pm_enemy_flags_addr                 0x800B0FC0
 #define pm_effects_addr                     0x800B4398
 #define pm_save_data_addr                   0x800DACC0
+#define pm_battle_state_2_addr              0x800DC4DC
 #define pm_battle_status_addr               0x800DC070
 #define pm_popup_menu_var_addr              0x8010D640
 #define pm_overworld_addr                   0x8010EBB0
@@ -897,6 +898,7 @@ typedef __OSEventState __osEventStateTab_t[];
 #define pm_unk4               (*(unk4_ctxt_t*)           pm_unk4_addr)
 #define pm_effects            (*(effects_ctxt_t*)        pm_effects_addr)
 #define pm_save_data          (*(save_data_ctxt_t*)      pm_save_data_addr)
+#define pm_battle_state_2     (*(int32_t*)               pm_battle_state_2_addr)
 #define pm_battle_status      (*(battle_status_ctxt_t*)  pm_battle_status_addr)
 #define pm_popup_menu_var     (*(int32_t*)               pm_popup_menu_var_addr)
 #define pm_overworld          (*(overworld_ctxt_t*)      pm_overworld_addr)
@@ -929,6 +931,7 @@ typedef __OSEventState __osEventStateTab_t[];
 #define pm_PlayAmbientSounds_addr           0x80147368
 #define pm_PlaySfx_addr                     0x80149CB4
 #define pm_SaveGame_addr                    0x802E11A0
+#define pm_func_802A472C_addr               0x802A472C
 #elif PM64_VERSION==PM64J
 #define osSyncPrintf_addr                   0x80025CFC
 #define __osPiGetAccess_addr                0x80061474
@@ -973,6 +976,7 @@ typedef int32_t (*pm_SetMapTransitionEffect_t) (int32_t transition);
 typedef void (*pm_PlaySfx_t) (int32_t sound_id);
 typedef void (*pm_PlayAmbientSounds_t) (int32_t sounds_id, int32_t fade_time);
 typedef void (*pm_SaveGame_t) ();
+typedef void (*pm_func_802A472C_t) ();
 
 /* Functions */
 #define osSyncPrintf                ((osSyncPrintf_t)                osSyncPrintf_addr)
@@ -995,6 +999,7 @@ typedef void (*pm_SaveGame_t) ();
 #define pm_SetMapTransitionEffect   ((pm_SetMapTransitionEffect_t)   pm_SetMapTransitionEffect_addr)
 #define pm_PlaySfx                  ((pm_PlaySfx_t)                  pm_PlaySfx_addr)
 #define pm_SaveGame                 ((pm_SaveGame_t)                 pm_SaveGame_addr)
+#define pm_func_802A472C             ((pm_func_802A472C_t)           pm_func_802A472C_addr)
 
 /* Convenience Values */
 #define STORY_PROGRESS pm_save_data.global_bytes[0]


### PR DESCRIPTION
- fix most known warping crashes by manually closing open pop up menus and such. For card obtained crash, hide the global curtains that would normally appear in the cutscene.

- adds the PRINTF macro which can be used as an alternative for debugging with a console, instead of printing to the game screen.
To use this you will need to grab the `is64_logging` script here and follow the instructions to set it up with pj64 https://github.com/Dragorn421/IS64-logging

- adds the NDEBUG define in the makefile. by default this is set to 0, but when building for release you can set it to 1 to disable debug features. For now, all this does is remove calls to the printf function so that the release binary doesnt contain all of our extra strings that we will be adding.

- unconditionally run the crc step at the end of the build process so that you dont have to specify it in make every time. I dont see a situation where you wouldnt want to recalc the crc, so I think this is more convenient 