### PR TITLE
improved OoT ACE trainer

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -238,11 +238,6 @@ void command_show_hide_timer_proc() {
 }
 
 void command_load_game_proc() {
-    // if (fp_warp_will_crash()) {
-    //     fp_log("can't load right now");
-    //     return;
-    // }
-
     save_data_ctxt_t *file = malloc(sizeof(*file));
     pm_FioFetchSavedFileInfo();
     pm_FioReadFlash(pm_save_info.logical_save_info[pm_status.save_slot][0], file, sizeof(*file));

--- a/src/fp.c
+++ b/src/fp.c
@@ -79,6 +79,9 @@ void fp_init() {
     fp.saved_entrance = 0;
     fp.saved_trick = -1;
     fp.turbo = 0;
+    fp.ace_last_timer = 0;
+    fp.ace_last_flag_status = 0;
+    fp.ace_last_jump_status = 0;
     fp.bowser_blocks_enabled = 0;
     fp.bowser_block = 0;
     fp.prev_prev_action_state = 0;

--- a/src/fp.h
+++ b/src/fp.h
@@ -52,6 +52,9 @@ typedef struct {
     uint16_t saved_room;
     uint16_t saved_entrance;
     int8_t ace_frame_window;
+    uint16_t ace_last_timer;
+    _Bool ace_last_flag_status;
+    _Bool ace_last_jump_status;
     _Bool turbo;
     _Bool bowser_blocks_enabled;
     int8_t bowser_block;


### PR DESCRIPTION
improves existing OoT ACE trainer to show timer, flag, and jump status upon a successful effect setup. this information is used along with the current frame window to determine if a jump to file names would have been successful, and the result is displayed in the trainer.

![image](https://user-images.githubusercontent.com/42006114/144727797-3050e743-442a-436b-8298-734c0fd8d045.png)