### PR TITLE
black and white icon option + add a free function

### DIFF
--- a/src/fp.c
+++ b/src/fp.c
@@ -230,7 +230,7 @@ void fp_emergency_settings_reset(u16 pad_pressed) {
 #define STRINGIFY_(S) #S
 void fp_draw_version(struct gfx_font *font, s32 cell_width, s32 cell_height, u8 menu_alpha) {
     if (pm_status.load_menu_state > 0) {
-        item_icon_draw(ITEM_FP_PLUS_A, 15, SCREEN_HEIGHT - 65, 255);
+        item_icon_draw(ITEM_FP_PLUS_A, 15, SCREEN_HEIGHT - 65, 255, ICON_COLOR);
         gfx_mode_set(GFX_MODE_COLOR, GPACK_RGBA8888(0xFF, 0, 0, 0xFF));
         gfx_printf(font, 16, SCREEN_HEIGHT - 35 + cell_height * 1, STRINGIFY(FP_VERSION));
         gfx_printf(font, SCREEN_WIDTH - cell_width * 21, SCREEN_HEIGHT - 35 + cell_height * 1, STRINGIFY(URL));

--- a/src/item_icons.h
+++ b/src/item_icons.h
@@ -18,5 +18,6 @@ typedef struct {
 } IconEntry;
 
 void item_icon_draw(u32 item_id, s32 x, s32 y, u8 alpha, u8 mode);
+void item_icon_free_all(void);
 
 #endif

--- a/src/item_icons.h
+++ b/src/item_icons.h
@@ -3,15 +3,20 @@
 
 #include "fp.h"
 
+typedef enum {
+    ICON_COLOR,
+    ICON_GRAYSCALE
+} IconColorMode;
+
 typedef struct {
-    u8 *texture; // pointer to icon texture, malloc'd on the heap
-    u8 *palette; // pointer to icon palette, malloc'd on the heap
-    u32 tex_rom; // rom start of the texture
-    u32 pal_rom; // rom start of the palette
-    u16 width;   // width of the texture
-    u16 height;  // height of the texture
+    u8 *texture;  // pointer to icon texture, malloc'd on the heap
+    u16 *palette; // pointer to icon palette, malloc'd on the heap
+    u32 tex_rom;  // rom start of the texture
+    u32 pal_rom;  // rom start of the palette
+    u16 width;    // width of the texture
+    u16 height;   // height of the texture
 } IconEntry;
 
-void item_icon_draw(u32 item_id, s32 x, s32 y, u8 alpha);
+void item_icon_draw(u32 item_id, s32 x, s32 y, u8 alpha, u8 mode);
 
 #endif

--- a/src/pm64.h
+++ b/src/pm64.h
@@ -1003,7 +1003,7 @@ void pm_SetGameMode(int32_t mode);
 void pm_RemoveEffect(EffectInstance *effect);
 void pm_FioReadFlash(int32_t slot, void *buffer, uint32_t size);
 void pm_FioWriteFlash(int32_t slot, void *buffer, uint32_t size);
-s32 draw_ci_image_with_clipping(u8 *texture, s32 width, s32 height, s32 fmt, s32 size, u8 *palette, s16 posX, s16 posY,
+s32 draw_ci_image_with_clipping(u8 *texture, s32 width, s32 height, s32 fmt, s32 size, u16 *palette, s16 posX, s16 posY,
                                 u16 clipULx, u16 clipULy, u16 clipLRx, u16 clipRLy, u8 opacity);
 int32_t pm_SetMapTransitionEffect(int32_t transition);
 void pm_PlaySfx(int32_t sound_id);


### PR DESCRIPTION
- now you can pass a color mode to the icon draw function to choose between color and black and white (ICON_COLOR + ICON_GRAYSCALE)
- adds a free function to clear the texture table. this will need to be tested to make sure it actually works when an icon based menu is built