### PR TITLE
Makefile rewrite

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -17,7 +17,9 @@ jobs:
         sudo sh -c '(curl https://practicerom.com/public/packages/debian/pgp.pub || wget -O - https://practicerom.com/public/packages/debian/pgp.pub) | apt-key add - && echo deb https://practicerom.com/public/packages/debian ./staging main >/etc/apt/sources.list.d/practicerom.list && apt update'
         sudo apt install practicerom-dev
     - name: Test build
-      run: make all
+      run: |
+        make -j16 VERSION=us
+        make -j16 VERSION=jp
   formatting-check:
     name: Formatting Check
     runs-on: ubuntu-latest

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -17,8 +17,8 @@ Clone the fp source code by running:
 
 `git clone https://github.com/jcog/fp.git`  
 
-To build all fp binaries, run `make` in the root directory of the fp repository.
-If you only want to patch a rom, you can skip this step and move on to the patching section.
+To build fp binaries, run `make VERSION=ver` with `ver` being either `us` or `jp`. This will only build the fp binaries and will not patch a rom.
+If you want to patch a rom, you can skip this step and move on to the patching section.
 
 # Patching
 ## N64
@@ -29,6 +29,8 @@ To create a patched ROM, run
 replacing `<rom-file>` with the path to a unmodified (and 100% legally obtained) Mario Story (J) or Paper Mario (U) ROM.
 
 If you do not specifiy an output rom with `-o <output-rom>`, the newly built fp rom will be located in the root directory as either `fp-jp.z64` or `fp-us.z64`.
+
+You can also specify additional arguments that will be passed to make using the `MAKEOPTS` environment variable
 
 ## Wii
 To create a patched WAD for use with Wii VC, you must have gzinject installed. If you followed the above instructions to install the prebuilt toolchain, this will already be installed. If not, follow the instructions [here](https://github.com/krimtonz/gzinject). You will also need to generate the Wii common key by running `gzinject -a genkey` in the root directory of the repository and following the instructions.

--- a/lua/make.lua
+++ b/lua/make.lua
@@ -11,34 +11,31 @@ if rom_info == nil then
     return 1
 end
 
-local fp_version = "fp-" .. rom_info.rom_id
-print("Building " .. fp_version)
+print("Building fp-" .. rom_info.rom_id)
+local makeopts = os.getenv("MAKEOPTS") or ""
 
-print("make " .. 
-fp_version ..
-" build/patch/" .. fp_version .. "/hooks.gsc")
-local _,_,res = os.execute("make " .. 
-                           fp_version ..
-                           " build/patch/" .. fp_version .. "/hooks.gsc")
+local make_fp = "make " .. makeopts .. " VERSION=" .. rom_info.rom_id .. " fp"
+print(make_fp)
+local _,_,res = os.execute(make_fp)
 if res ~= 0 then
     error("could not build fp", 0)
 end
 
-local hooks = gru.gsc_load("build/patch/" .. fp_version .. "/hooks.gsc")
+local hooks = gru.gsc_load("build/patch/" .. rom_info.rom_id .. "/hooks.gsc")
 
 print("Applying hooks")
 hooks:shift(-rom_info.rom_to_ram)
 hooks:apply_be(rom)
 
 local old_ldr = rom:copy(rom_info.ldr_rom, 0x54)
-local fp = gru.blob_load("build/bin/" .. fp_version .. "/fp.bin")
+local fp = gru.blob_load("build/bin/" .. rom_info.rom_id .. "/fp.bin")
 local payload_rom = rom_info.payload_addr
 local fp_rom = payload_rom + 0x60
 
 print("Building Loader")
 
-local make_ldr = string.format("make -B CPPFLAGS=' -DPAYLOAD=0x%06x -DDMA_COPY=0x%08x -DEND=0x%08x' LDFLAGS=' -Wl,--defsym,start=0x%08x'" ..
-                                " ldr-" .. fp_version, rom_info.payload_addr, rom_info.dma_func, fp:size() + fp_rom, rom_info.ldr_addr)
+local make_ldr = string.format("make -B CPPFLAGS=' -DPAYLOAD=0x%06x -DDMA_COPY=0x%08x -DEND=0x%08x' LDFLAGS=' -Wl,--defsym,start=0x%08x' " ..
+                                makeopts .. " VERSION=" .. rom_info.rom_id .. " ldr", rom_info.payload_addr, rom_info.dma_func, fp:size() + fp_rom, rom_info.ldr_addr)
 
 print(make_ldr)
 local _,_,res = os.execute(make_ldr)
@@ -46,12 +43,12 @@ if(res ~= 0) then
     error("Could not build loader", 0)
 end
 
-local ldr = gru.blob_load("build/bin/ldr-" .. fp_version .. "/ldr.bin")
+local ldr = gru.blob_load("build/bin/" .. rom_info.rom_id .. "/ldr.bin")
 
 print("Inserting payload")
 rom:write(rom_info.ldr_rom, ldr)
 rom:write(payload_rom, old_ldr)
-local payload = gru.blob_load("build/bin/" .. fp_version .. "/fp.bin")
+local payload = gru.blob_load("build/bin/" .. rom_info.rom_id .. "/fp.bin")
 rom:write(fp_rom, fp)
 rom:crc_update()
 

--- a/lua/rom_info.lua
+++ b/lua/rom_info.lua
@@ -4,7 +4,7 @@ roms = {
         ldr_rom = 0x25E2C,
         ldr_addr = 0x8004AA2C,
         dma_func = 0x800296FC,
-        rom_id = "JP",
+        rom_id = "jp",
         payload_addr = 0x1C7F220,
     },
     [0xA7F5CD7E] = {
@@ -12,7 +12,7 @@ roms = {
         ldr_rom = 0x2617C,
         ldr_addr = 0x8004AD7C,
         dma_func = 0x8002973C,
-        rom_id = "US",
+        rom_id = "us",
         payload_addr = 0x1C84D30,
     }
 }

--- a/makefile
+++ b/makefile
@@ -30,7 +30,7 @@ ELF            = $(BINDIR)/fp.elf
 BIN            = $(BINDIR)/fp.bin
 LDR_ELF        = $(BINDIR)/ldr.elf
 LDR_BIN        = $(BINDIR)/ldr.bin
-HOOKS          = $(HOOKS)
+HOOKS          = $(HOOKSDIR)/hooks.gsc
 NDEBUG        ?= 0
 VERSION       ?= jp
 

--- a/makefile
+++ b/makefile
@@ -1,10 +1,10 @@
-URL           ?= github.com/jcog/fp
+URL            ?= github.com/jcog/fp
 ifeq ($(origin FP_VERSION), undefined)
-  TAG_COMMIT    := $(shell git rev-list --abbrev-commit --tags --max-count=1)
-  TAG           := $(shell git describe --abbrev=0 --tags ${TAG_COMMIT} 2>/dev/null || true)
-  COMMIT        := $(shell git rev-parse --short HEAD)
-  DATE          := $(shell git log -1 --format=%cd --date=format:"%m-%d-%y")
-  FP_VERSION    := $(COMMIT)-$(DATE)
+  TAG_COMMIT     := $(shell git rev-list --abbrev-commit --tags --max-count=1)
+  TAG            := $(shell git describe --abbrev=0 --tags ${TAG_COMMIT} 2>/dev/null || true)
+  COMMIT         := $(shell git rev-parse --short HEAD)
+  DATE           := $(shell git log -1 --format=%cd --date=format:"%m-%d-%y")
+  FP_VERSION     := $(COMMIT)-$(DATE)
   ifeq ('$(TAG_COMMIT)', '$(COMMIT)')
     ifneq ('$(TAG)', '')
       FP_VERSION := $(TAG)
@@ -18,7 +18,6 @@ OBJCOPY        = mips64-objcopy
 GRC            = grc
 GENHOOKS       = CPPFLAGS='$(subst ','\'', $(CPPFLAGS))' ./genhooks
 SRCDIR         = src
-ASMDIR         = $(SRCDIR)/asm
 BUILDDIR       = build
 LIBDIR         = lib
 RESDIR         = res
@@ -31,67 +30,66 @@ ELF            = $(BINDIR)/fp.elf
 BIN            = $(BINDIR)/fp.bin
 LDR_ELF        = $(BINDIR)/ldr.elf
 LDR_BIN        = $(BINDIR)/ldr.bin
+HOOKS          = $(HOOKS)
 NDEBUG        ?= 0
-VERSION       ?= us
+VERSION       ?= jp
 
 FP_BIN_ADDRESS = 0x80400060
 CFLAGS         = -c -MMD -MP -std=gnu11 -Wall -ffunction-sections -fdata-sections -O2 -fno-reorder-blocks
-CPPFLAGS       = -DURL=$(URL) -DFP_VERSION=$(FP_VERSION) -DF3DEX_GBI_2 $(CPPFLAGS)
-LDFLAGS        = -T gl-n64.ld -L$(LIBDIR) -nostartfiles -specs=nosys.specs -Wl,--gc-sections -Wl,--defsym,start=$(FP_BIN_ADDRESS) $(LDFLAGS)
+ALL_CPPFLAGS   = -DURL=$(URL) -DFP_VERSION=$(FP_VERSION) -DF3DEX_GBI_2 $(CPPFLAGS)
+ALL_LDFLAGS    = -T gl-n64.ld -L$(LIBDIR) -nostartfiles -specs=nosys.specs -Wl,--gc-sections -Wl,--defsym,start=$(FP_BIN_ADDRESS) $(LDFLAGS)
 
 ifeq ($(NDEBUG), 1)
-  CFLAGS   += -DNDEBUG
-  CPPFLAGS += -DNDEBUG
+  CFLAGS       += -DNDEBUG
+  ALL_CPPFLAGS += -DNDEBUG
 endif
 
 ifeq ($(VERSION), us)
-  CPPFLAGS += -DPM64_VERSION=US
-  LDFLAGS  += -Wl,-Map=$(BUILDDIR)/fp-us.map
-  LIBS     := -lpm-us
+  ALL_CPPFLAGS += -DPM64_VERSION=US
+  ALL_LDFLAGS  += -Wl,-Map=$(BUILDDIR)/fp-us.map
+  LIBS          = -lpm-us
 else ifeq ($(VERSION), jp)
-  CPPFLAGS += -DPM64_VERSION=JP
-  LDFLAGS  += -Wl,-Map=$(BUILDDIR)/fp-jp.map
-  LIBS     := -lpm-jp
+  ALL_CPPFLAGS += -DPM64_VERSION=JP
+  ALL_LDFLAGS  += -Wl,-Map=$(BUILDDIR)/fp-jp.map
+  LIBS          = -lpm-jp
 else
   $(error VERSION must be either us or jp)
 endif
 
 C_FILES   := $(wildcard $(SRCDIR)/*.c)
-S_FILES   := $(wildcard $(SRCDIR)/*.s)
 RES_FILES := $(wildcard $(RESDIR)/fp/*.png)
-O_FILES   := $(addprefix $(OBJDIR)/, $(addsuffix .o, $(notdir $(basename $(C_FILES))))) \
-             $(addprefix $(OBJDIR)/, $(addsuffix .o, $(notdir $(basename $(S_FILES))))) \
+OBJ       := $(addprefix $(OBJDIR)/, $(addsuffix .o, $(notdir $(basename $(C_FILES))))) \
              $(addprefix $(OBJDIR)/$(RESDIR)/, $(addsuffix .o, $(notdir $(basename $(RES_FILES)))))
 
 .PHONY: fp ldr clean
-fp: $(BIN) $(HOOKSDIR)/hooks.gsc
-ldr: $(BINDIR)/ldr.bin
+fp: $(BIN) $(HOOKS)
+ldr: $(LDR_BIN)
 clean:
 	rm -rf $(BUILDDIR)
 	rm -f fp-jp.z64 fp-us.z64 fp-US.wad fp-JP.wad romc
 romc: romc.c
 	gcc -O2 $< -o $@
 
-$(HOOKSDIR)/hooks.gsc: $(ELF) | $(HOOKSDIR)
+$(HOOKS): $(ELF) | $(HOOKSDIR)
 	$(GENHOOKS) $< > $@
 
 $(BIN): $(ELF) | $(BINDIR)
 	$(OBJCOPY) -S -O binary $< $@
 
-$(ELF): $(O_FILES) | $(BINDIR)
-	$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
+$(ELF): $(OBJ) | $(BINDIR)
+	$(LD) $(ALL_LDFLAGS) -o $@ $^ $(LIBS)
 
 $(OBJDIR)/%.o: $(SRCDIR)/%.c | $(OBJDIR)
-	$(CC) -c $(CPPFLAGS) $(CFLAGS) -o $@ $<
+	$(CC) -c $(ALL_CPPFLAGS) $(CFLAGS) -o $@ $<
 
 $(OBJDIR)/$(RESDIR)/%.o: $(RESDIR)/fp/%.png $(RESDESC) | $(OBJDIR)/$(RESDIR)
 	$(GRC) $< -d $(RESDESC) -o $@
 
-$(BINDIR)/$(LDR_BIN): $(BINDIR)/$(LDR_ELF) | $(BINDIR)
+$(LDR_BIN): $(LDR_ELF) | $(BINDIR)
 	$(OBJCOPY) -S -O binary $< $@
 
-$(BINDIR)/$(LDR_ELF): $(ASMDIR)/%.s | $(BINDIR)
-	$(AS) -MMD -MP $(CPPFLAGS) $(LDFLAGS) $< -o $@ $(LIBS)
+$(LDR_ELF): $(SRCDIR)/asm/ldr.s | $(BINDIR)
+	$(AS) -MMD -MP $(ALL_CPPFLAGS) $(ALL_LDFLAGS) $< -o $@ $(LIBS)
 
 $(OUTDIR):
 	@mkdir -p $@

--- a/makefile
+++ b/makefile
@@ -37,7 +37,7 @@ VERSION       ?= jp
 FP_BIN_ADDRESS = 0x80400060
 CFLAGS         = -c -MMD -MP -std=gnu11 -Wall -ffunction-sections -fdata-sections -O2 -fno-reorder-blocks
 ALL_CPPFLAGS   = -DURL=$(URL) -DFP_VERSION=$(FP_VERSION) -DF3DEX_GBI_2 $(CPPFLAGS)
-ALL_LDFLAGS    = -T gl-n64.ld -L$(LIBDIR) -nostartfiles -specs=nosys.specs -Wl,--gc-sections -Wl,--defsym,start=$(FP_BIN_ADDRESS) $(LDFLAGS)
+ALL_LDFLAGS    = -T gl-n64.ld -L$(LIBDIR) -nostartfiles -specs=nosys.specs -Wl,--gc-sections $(LDFLAGS)
 
 ifeq ($(NDEBUG), 1)
   CFLAGS       += -DNDEBUG
@@ -77,7 +77,7 @@ $(BIN): $(ELF) | $(BINDIR)
 	$(OBJCOPY) -S -O binary $< $@
 
 $(ELF): $(OBJ) | $(BINDIR)
-	$(LD) $(ALL_LDFLAGS) -o $@ $^ $(LIBS)
+	$(LD) $(ALL_LDFLAGS) -Wl,--defsym,start=$(FP_BIN_ADDRESS) -o $@ $^ $(LIBS)
 
 $(OBJDIR)/%.o: $(SRCDIR)/%.c | $(OBJDIR)
 	$(CC) -c $(ALL_CPPFLAGS) $(CFLAGS) -o $@ $<


### PR DESCRIPTION
- Makefile rewritten to be more readable
- Instead of having each version as a separate target, version is specified using `VERSION` variable
- Updates build scripts and documentation accordingly
- makerom script supports passing arguments to make using `MAKEOPTS` variable