### PR TITLE
Loading zone timer

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -127,9 +127,10 @@ The **trainers** menu contains various different helpful menus and information s
 #### 2.5.2 Timer
 The **timer** menu provides a real-time timer that is unaffected by lag. Separately, it also displays 30 fps lag frames by taking half of the game's vertical interrupt counter and subtracting the number of game frames that have passed. Note that lag frames can decrease due to the game speeding up to account for lag. Additionally, the timer is only guaranteed to be accurate on console.
 
-The timer has two modes, **automatic** and **manual**.
+The timer has three modes: **cutscene**, **loading zone**, and **manual**.
 
-- **automatic**: In this mode, pressing `start/stop` will prime the timer to start, but it won't start right away. Instead, once primed, the timer will begin the next time a cutscene ends. A cutscene, in this context, is anything that takes the player's control away from Mario, such as entering a loading zone or opening a menu. The timer will then continue to run until the number of cutscenes that have occurred equals the configurable `cutscene count`. In this way, any arbitrary sequence of events can be timed without worrying about human error affecting the starting/stopping of the timer.
+- **cutscene**: In this mode, pressing `start/stop` will prime the timer to start, but it won't start right away. Instead, once primed, the timer will begin the next time a cutscene ends. A cutscene, in this context, is anything that takes the player's control away from Mario, such as entering a loading zone or opening a menu. The timer will then continue to run until the number of cutscenes that have occurred equals the configurable `cutscene count`. In this way, any arbitrary sequence of events can be timed without worrying about human error affecting the starting/stopping of the timer.
+- **loading zone**: This mode functions identically to cutscene mode, but only map changes will trigger it.
 - **manual**: This mode is much simpler. Pressing `start/stop` will start the timer immediately, and it will continue to run unless `start/stop` or `reset` is pressed.
 
 The timer will continue to function even if the utility menu is closed, but by default it will not be displayed when running due to lag concerns. Additionally, no log messages related to the timer will be displayed when the timer is running. These can be changed by toggling the `show timer` and `timer logging` options.

--- a/src/commands.c
+++ b/src/commands.c
@@ -22,7 +22,7 @@ struct Command fpCommands[COMMAND_MAX] = {
     {"reimport save",    COMMAND_PRESS_ONCE, 0, commandImportSaveProc    },
     {"save game",        COMMAND_PRESS_ONCE, 0, commandSaveGameProc      },
     {"load game",        COMMAND_PRESS_ONCE, 0, commandLoadGameProc      },
-    {"start/stop timer", COMMAND_PRESS_ONCE, 0, commandStartTimerProc    },
+    {"start/stop timer", COMMAND_PRESS_ONCE, 0, commandStartStopTimerProc},
     {"reset timer",      COMMAND_PRESS_ONCE, 0, commandResetTimerProc    },
     {"show/hide timer",  COMMAND_PRESS_ONCE, 0, commandShowHideTimerProc },
     {"break free",       COMMAND_PRESS_ONCE, 0, commandBreakFreeProc     },
@@ -233,8 +233,8 @@ void commandSaveGameProc(void) {
     fpLog("saved to slot %d", pm_gGameStatus.saveSlot);
 }
 
-void commandStartTimerProc(void) {
-    timerStart();
+void commandStartStopTimerProc(void) {
+    timerStartStop();
 }
 
 void commandResetTimerProc(void) {

--- a/src/commands.h
+++ b/src/commands.h
@@ -51,7 +51,7 @@ void commandToggleWatchesProc(void);
 void commandImportSaveProc(void);
 void commandSaveGameProc(void);
 void commandLoadGameProc(void);
-void commandStartTimerProc(void);
+void commandStartStopTimerProc(void);
 void commandResetTimerProc(void);
 void commandShowHideTimerProc(void);
 void commandBreakFreeProc(void);

--- a/src/fp.c
+++ b/src/fp.c
@@ -327,6 +327,9 @@ void fpDrawTimer(struct GfxFont *font, s32 cellWidth, s32 cellHeight, u8 menuAlp
     }
 
     gfxPrintf(font, x, y + cellHeight, "%d", timerGetLagFrames());
+    if (timerGetMode() != TIMER_MANUAL) {
+        gfxPrintf(font, x, y + cellHeight * 2, "%d/%d", timerGetCutsceneCount(), timerGetCutsceneTarget());
+    }
 }
 
 void fpUpdateCheats(void) {

--- a/src/fp/practice/timer.c
+++ b/src/fp/practice/timer.c
@@ -114,6 +114,9 @@ static s32 timerDrawProc(struct MenuItem *item, struct MenuDrawParams *drawParam
         gfxPrintf(font, x, y, "timer  %d.%02d", seconds, hundredths);
     }
     gfxPrintf(font, x, y + chHeight, "lag    %d", lagFrames >= 0 ? lagFrames : 0);
+    if (timerMode != TIMER_MANUAL) {
+        gfxPrintf(font, x, y + chHeight * 2, "cs/lz  %d/%d", cutsceneCount, cutsceneTarget);
+    }
     return 1;
 }
 
@@ -132,6 +135,10 @@ static s32 timerStatusDrawProc(struct MenuItem *item, struct MenuDrawParams *dra
     return 1;
 }
 
+enum TimerMode timerGetMode(void) {
+    return timerMode;
+}
+
 enum TimerState timerGetState(void) {
     return timerState;
 }
@@ -142,6 +149,14 @@ s64 timerGetTimerCount(void) {
 
 s32 timerGetLagFrames(void) {
     return lagFrames;
+}
+
+u8 timerGetCutsceneTarget(void) {
+    return cutsceneTarget;
+}
+
+u8 timerGetCutsceneCount(void) {
+    return cutsceneCount;
 }
 
 void timerUpdate(void) {
@@ -240,6 +255,7 @@ void createTimerMenu(struct Menu *menu) {
     menuAddStatic(menu, 0, y, "status", 0xC0C0C0);
     menuAddStaticCustom(menu, 7, y++, timerStatusDrawProc, NULL, 0xC0C0C0);
     menuAddStaticCustom(menu, 0, y++, timerDrawProc, NULL, 0xC0C0C0);
+    y++;
     y++;
     menuAddButton(menu, 0, y, "start/stop", startStopProc, NULL);
     menuAddButton(menu, 11, y++, "reset", resetProc, NULL);

--- a/src/fp/practice/timer.h
+++ b/src/fp/practice/timer.h
@@ -3,7 +3,8 @@
 #include "menu/menu.h"
 
 enum TimerMode {
-    TIMER_AUTO,
+    TIMER_CUTSCENE,
+    TIMER_LOADING_ZONE,
     TIMER_MANUAL,
 };
 
@@ -19,7 +20,7 @@ s64 timerGetTimerCount(void);
 s32 timerGetLagFrames(void);
 
 void timerUpdate(void);
-void timerStart(void);
+void timerStartStop(void);
 void timerReset(void);
 
 void createTimerMenu(struct Menu *menu);

--- a/src/fp/practice/timer.h
+++ b/src/fp/practice/timer.h
@@ -15,9 +15,12 @@ enum TimerState {
     TIMER_STOPPED,
 };
 
+enum TimerMode timerGetMode(void);
 enum TimerState timerGetState(void);
 s64 timerGetTimerCount(void);
 s32 timerGetLagFrames(void);
+u8 timerGetCutsceneTarget(void);
+u8 timerGetCutsceneCount(void);
 
 void timerUpdate(void);
 void timerStartStop(void);


### PR DESCRIPTION
Adds an auto-timer mode for loading zones. Similar to cutscenes, but only triggers on map changes. Timer starts on gaining control after a LZ change and ends upon losing control after touching the last LZ.

Smaller changes included are a display to count CS/LZs while the timer is running and the ability to manually stop the timer when in CS/LZ mode without resetting.

Still has the issue where riding Laki/Sushie prevents it from triggering. Should look into that eventually, but it'll require changing how cutscenes are detected, which may or may not end up being pretty difficult.