### PR TITLE
Mute music cheat

### DIFF
--- a/lib/libpm-jp.a
+++ b/lib/libpm-jp.a
@@ -27,6 +27,7 @@ pm_gPartnerActionStatus = 0x8010ED70;
 pm_gUiStatus = 0x8010F118;
 pm_gPlayerStatus = 0x8010F188;
 pm_gHudElementSizes = 0x8015406C;
+pm_musicCurrentVolume = 0x8015EA66;
 pm_gActionCommandStatus = 0x8029FED0;
 pm_gNumScripts = 0x802DA488;
 pm_gCurrentScriptListPtr = 0x802DA890;

--- a/lib/libpm-us.a
+++ b/lib/libpm-us.a
@@ -27,6 +27,7 @@ pm_gPartnerActionStatus = 0x8010EBB0;
 pm_gUiStatus = 0x8010EF58;
 pm_gPlayerStatus = 0x8010EFC8;
 pm_gHudElementSizes = 0x8014EFCC;
+pm_musicCurrentVolume = 0x80159AE6;
 pm_gActionCommandStatus = 0x8029FBE0;
 pm_gNumScripts = 0x802DA488;
 pm_gCurrentScriptListPtr = 0x802DA890;

--- a/src/fp.c
+++ b/src/fp.c
@@ -324,6 +324,10 @@ void fpUpdateCheats(void) {
     if (CHEAT_ACTIVE(CHEAT_HIDE_HUD)) {
         pm_gUiStatus.hidden = TRUE;
     }
+    if (CHEAT_ACTIVE(CHEAT_MUTE_MUSIC)) {
+        // the game is constantly trying to raise this by 1 every frame, so 0 would just make it quiet instead of muted
+        pm_musicCurrentVolume = -1;
+    }
     if (CHEAT_ACTIVE(CHEAT_AUTO_ACTION_CMD)) {
         pm_gActionCommandStatus.autoSucceed = 1;
     }

--- a/src/fp/file/fp_file.c
+++ b/src/fp/file/fp_file.c
@@ -52,18 +52,6 @@ static s32 byteOptionmodProc(struct MenuItem *item, enum MenuCallbackReason reas
     return 0;
 }
 
-static s32 checkboxModProc(struct MenuItem *item, enum MenuCallbackReason reason, void *data) {
-    u8 *p = data;
-    if (reason == MENU_CALLBACK_SWITCH_ON) {
-        *p = 1;
-    } else if (reason == MENU_CALLBACK_SWITCH_OFF) {
-        *p = 0;
-    } else if (reason == MENU_CALLBACK_THINK) {
-        menuCheckboxSet(item, *p);
-    }
-    return 0;
-}
-
 static s32 storyProgressDrawProc(struct MenuItem *item, struct MenuDrawParams *drawParams) {
     gfxModeSet(GFX_MODE_COLOR, GPACK_RGB24A8(drawParams->color, drawParams->alpha));
     struct GfxFont *font = drawParams->font;
@@ -258,11 +246,10 @@ struct Menu *createFileMenu(void) {
     menuItemAddChainLink(plusButton, progressInput, MENU_NAVIGATE_DOWN);
     y++;
 
-    menuAddStatic(&menu, 0, y, "music", 0xC0C0C0);
-    struct MenuItem *musicCheckbox = menuAddCheckbox(&menu, menuX, y++, checkboxModProc, &pm_gGameStatus.musicEnabled);
-    menuItemAddChainLink(musicCheckbox, progressInput, MENU_NAVIGATE_UP);
     menuAddStatic(&menu, 0, y, "quizmo", 0xC0C0C0);
-    menuAddIntinput(&menu, menuX, y++, 10, 2, byteModProc, &pm_gCurrentSaveFile.globalBytes[0x161]);
+    struct MenuItem *quizmoInput =
+        menuAddIntinput(&menu, menuX, y++, 10, 2, byteModProc, &pm_gCurrentSaveFile.globalBytes[0x161]);
+    menuItemAddChainLink(quizmoInput, progressInput, MENU_NAVIGATE_UP);
     menuAddStatic(&menu, 0, y, "toy box 1", 0xC0C0C0);
     menuAddOption(&menu, menuX, y++,
                   "goomba\0"

--- a/src/fp/fp_cheats.c
+++ b/src/fp/fp_cheats.c
@@ -7,7 +7,7 @@ static const char *labels[] = {
     "star pieces", "peril",
     "auto mash",   "auto action command",
     "peekaboo",    "brighten room",
-    "hide hud",
+    "hide hud",    "mute music",
 };
 
 static s32 battleProc(struct MenuItem *item, enum MenuCallbackReason reason, void *data) {

--- a/src/pm64.h
+++ b/src/pm64.h
@@ -1235,6 +1235,7 @@ extern_data pm_PartnerActionStatus pm_gPartnerActionStatus;
 extern_data pm_UiStatus pm_gUiStatus;
 extern_data pm_PlayerStatus pm_gPlayerStatus;
 extern_data pm_HudElementSize pm_gHudElementSizes[26];
+extern_data s16 pm_musicCurrentVolume;
 extern_data pm_ActionCommandStatus pm_gActionCommandStatus;
 extern_data s32 pm_gNumScripts;
 extern_data pm_ScriptList *pm_gCurrentScriptListPtr;

--- a/src/sys/settings.h
+++ b/src/sys/settings.h
@@ -23,6 +23,7 @@ enum Cheats {
     CHEAT_PEEKABOO,
     CHEAT_BRIGHTEN_ROOM,
     CHEAT_HIDE_HUD,
+    CHEAT_MUTE_MUSIC,
     CHEAT_MAX
 };
 


### PR DESCRIPTION
The previous mute music option was reset every time you loaded a file. This cheat just forces the volume to 0 every frame, which is much more effective and can be saved as part of your settings.