### PR TITLE
Enemy contact cheat rework

### DIFF
--- a/src/fp.c
+++ b/src/fp.c
@@ -294,6 +294,7 @@ void fpDrawTimer(struct GfxFont *font, s32 cellWidth, s32 cellHeight, u8 menuAlp
 }
 
 void fpUpdateCheats(void) {
+    pm_gGameStatus.debugEnemyContact = settings->cheatEnemyContact;
     if (CHEAT_ACTIVE(CHEAT_HP)) {
         pm_gPlayerStatus.playerData.curHP = pm_gPlayerStatus.playerData.maxHP;
     }

--- a/src/fp/fp_cheats.c
+++ b/src/fp/fp_cheats.c
@@ -1,3 +1,4 @@
+#include "fp.h"
 #include "menu/menu.h"
 #include "sys/settings.h"
 
@@ -52,28 +53,31 @@ struct Menu *createCheatsMenu(void) {
 
     /* initialize menu */
     menuInit(&menu, MENU_NOVALUE, MENU_NOVALUE, MENU_NOVALUE);
-    menu.selector = menuAddSubmenu(&menu, 0, 0, NULL, "return");
+    s32 y = 0;
+    menu.selector = menuAddSubmenu(&menu, 0, y++, NULL, "return");
 
     /*build menu*/
-    menuAddStatic(&menu, 0, 1, "encounters", 0xC0C0C0);
-    struct MenuItem *encountersOption = menuAddOption(&menu, 11, 1,
+    menuAddStatic(&menu, 0, y, "encounters", 0xC0C0C0);
+    struct MenuItem *encountersOption = menuAddOption(&menu, 11, y++,
                                                       "normal\0"
                                                       "no encounters\0"
                                                       "defeat on contact\0"
                                                       "auto-win\0"
                                                       "auto-runaway\0",
                                                       byteOptionmodProc, &settings->cheatEnemyContact);
-    s32 i;
+    y++;
     menuItemAddChainLink(menu.selector, encountersOption, MENU_NAVIGATE_DOWN);
-    for (i = 0; i < CHEAT_MAX; ++i) {
-        struct MenuItem *option = menuAddCheckbox(&menu, 0, 3 + i, cheatProc, (void *)i);
-        menuAddStatic(&menu, 2, 3 + i, labels[i], 0xC0C0C0);
+    for (s32 i = 0; i < CHEAT_MAX; i++) {
+        struct MenuItem *option = menuAddCheckbox(&menu, 0, y, cheatProc, (void *)i);
+        menuAddStatic(&menu, 2, y++, labels[i], 0xC0C0C0);
         if (i == 0) {
             menuItemAddChainLink(option, encountersOption, MENU_NAVIGATE_UP);
         }
     }
-    menuAddCheckbox(&menu, 0, 3 + i, quizmoProc, NULL);
-    menuAddStatic(&menu, 2, 3 + i, "quizmo spawns", 0xC0C0C0);
+    menuAddCheckbox(&menu, 0, y, quizmoProc, NULL);
+    menuAddStatic(&menu, 2, y++, "quizmo spawns", 0xC0C0C0);
+    y++;
+    menuAddButton(&menu, 0, y++, "save settings", fpSaveSettingsProc, NULL);
 
     return &menu;
 }

--- a/src/fp/fp_cheats.c
+++ b/src/fp/fp_cheats.c
@@ -6,7 +6,7 @@ static const char *labels[] = {
     "hp",          "fp",
     "coins",       "star power",
     "star pieces", "peril",
-    "auto mash",   "auto action command",
+    "auto mash",   "action commands",
     "peekaboo",    "brighten room",
     "hide hud",    "mute music",
 };

--- a/src/fp/fp_cheats.c
+++ b/src/fp/fp_cheats.c
@@ -3,12 +3,9 @@
 #include "sys/settings.h"
 
 static const char *labels[] = {
-    "hp",          "fp",
-    "coins",       "star power",
-    "star pieces", "peril",
-    "auto mash",   "action commands",
-    "peekaboo",    "brighten room",
-    "hide hud",    "mute music",
+    "hp",       "fp",         "coins",           "star power", "star pieces",
+    "peril",    "auto mash",  "action commands", "peekaboo",   "brighten room",
+    "hide hud", "mute music",
 };
 
 static s32 byteOptionmodProc(struct MenuItem *item, enum MenuCallbackReason reason, void *data) {

--- a/src/fp/fp_cheats.c
+++ b/src/fp/fp_cheats.c
@@ -10,14 +10,14 @@ static const char *labels[] = {
     "hide hud",    "mute music",
 };
 
-static s32 battleProc(struct MenuItem *item, enum MenuCallbackReason reason, void *data) {
+static s32 byteOptionmodProc(struct MenuItem *item, enum MenuCallbackReason reason, void *data) {
+    u8 *p = data;
     if (reason == MENU_CALLBACK_THINK_INACTIVE) {
-        if (menuOptionGet(item) != pm_gGameStatus.debugEnemyContact) {
-            menuOptionSet(item, pm_gGameStatus.debugEnemyContact);
+        if (menuOptionGet(item) != *p) {
+            menuOptionSet(item, *p);
         }
     } else if (reason == MENU_CALLBACK_DEACTIVATE) {
-        pm_gGameStatus.debugEnemyContact = menuOptionGet(item);
-        settings->bits.battleDebug = pm_gGameStatus.debugEnemyContact;
+        *p = menuOptionGet(item);
     }
     return 0;
 }
@@ -62,7 +62,7 @@ struct Menu *createCheatsMenu(void) {
                                                       "defeat on contact\0"
                                                       "auto-win\0"
                                                       "auto-runaway\0",
-                                                      battleProc, NULL);
+                                                      byteOptionmodProc, &settings->cheatEnemyContact);
     s32 i;
     menuItemAddChainLink(menu.selector, encountersOption, MENU_NAVIGATE_DOWN);
     for (i = 0; i < CHEAT_MAX; ++i) {

--- a/src/menu/menu_def.c
+++ b/src/menu/menu_def.c
@@ -2,7 +2,7 @@
 #include "sys/gfx.h"
 #include <stdlib.h>
 
-struct static_icon_data {
+struct StaticIconData {
     struct GfxTexture *texture;
     s32 textureTile;
     f32 scale;
@@ -15,7 +15,7 @@ struct MenuItem *menuAddStatic(struct Menu *menu, s32 x, s32 y, const char *text
 }
 
 static s32 staticIconDrawProc(struct MenuItem *item, struct MenuDrawParams *drawParams) {
-    struct static_icon_data *data = item->data;
+    struct StaticIconData *data = item->data;
     s32 cw = menuGetCellWidth(item->owner, TRUE);
     s32 w = data->texture->tileWidth * data->scale;
     s32 h = data->texture->tileHeight * data->scale;
@@ -39,7 +39,7 @@ static s32 staticIconDrawProc(struct MenuItem *item, struct MenuDrawParams *draw
 
 struct MenuItem *menuAddStaticIcon(struct Menu *menu, s32 x, s32 y, struct GfxTexture *texture, s32 textureTile,
                                    u32 color, f32 scale) {
-    struct static_icon_data *data = malloc(sizeof(*data));
+    struct StaticIconData *data = malloc(sizeof(*data));
     data->texture = texture;
     data->textureTile = textureTile;
     data->scale = scale;

--- a/src/sys/settings.c
+++ b/src/sys/settings.c
@@ -52,6 +52,7 @@ void settingsLoadDefault(void) {
     d->cheats = 0;
     d->controlStick = 0;
     d->controlStickRange = 90;
+    d->cheatEnemyContact = 0;
     d->binds[COMMAND_MENU] = bindMake(2, BUTTON_R, BUTTON_D_UP);
     d->binds[COMMAND_RETURN] = bindMake(2, BUTTON_R, BUTTON_D_LEFT);
     d->binds[COMMAND_LEVITATE] = bindMake(1, BUTTON_D_UP);

--- a/src/sys/settings.c
+++ b/src/sys/settings.c
@@ -31,6 +31,7 @@ void settingsLoadDefault(void) {
     settingsStore.header.dataSize = sizeof(settingsStore.data);
     struct SettingsData *d = &settingsStore.data;
 
+    d->cheats = 0;
     d->bits.fontResource = RES_FONT_PRESSSTART2P;
     d->bits.dropShadow = 1;
     d->bits.inputDisplay = 0;
@@ -48,11 +49,6 @@ void settingsLoadDefault(void) {
     d->logY = SCREEN_HEIGHT - 33;
     d->timerX = 16;
     d->timerY = 68;
-    d->nWatches = 0;
-    d->cheats = 0;
-    d->controlStick = 0;
-    d->controlStickRange = 90;
-    d->cheatEnemyContact = 0;
     d->binds[COMMAND_MENU] = bindMake(2, BUTTON_R, BUTTON_D_UP);
     d->binds[COMMAND_RETURN] = bindMake(2, BUTTON_R, BUTTON_D_LEFT);
     d->binds[COMMAND_LEVITATE] = bindMake(1, BUTTON_D_UP);
@@ -72,6 +68,10 @@ void settingsLoadDefault(void) {
     d->binds[COMMAND_BREAK_FREE] = bindMake(2, BUTTON_L, BUTTON_D_DOWN);
     d->binds[COMMAND_TOGGLE_INPUT_DISPLAY] = bindMake(0);
     d->binds[COMMAND_CLIPPY] = bindMake(0);
+    d->cheatEnemyContact = 0;
+    d->controlStickRange = 90;
+    d->controlStick = 0;
+    d->nWatches = 0;
 }
 
 void applyMenuSettings(void) {

--- a/src/sys/settings.h
+++ b/src/sys/settings.h
@@ -5,7 +5,7 @@
 
 #define SETTINGS_SAVE_FILE_SIZE 0x1380
 #define SETTINGS_PROFILE_MAX    4
-#define SETTINGS_VERSION        5
+#define SETTINGS_VERSION        6
 #define SETTINGS_FIO_PAGE       7
 
 #define SETTINGS_WATCHES_MAX    18
@@ -70,6 +70,7 @@ struct SettingsData {
     s16 watchX[SETTINGS_WATCHES_MAX];
     s16 watchY[SETTINGS_WATCHES_MAX];
     u16 binds[SETTINGS_BIND_MAX];
+    s8 cheatEnemyContact;
     s8 controlStickRange;
     u8 controlStick;
     struct WatchInfo watchInfo[SETTINGS_WATCHES_MAX];


### PR DESCRIPTION
For some reason the vanilla debug byte used for the encounters cheat is part of in-game saves, so this reworks that cheat to not care about that. Before, loading a file would load whatever value was in that file, usually normal behavior. This also lets us save the encounters cheat in your settings along with the rest of the cheats.

Also added a save settings button to the cheat menu.