### PR TITLE
Fix tidal wave crash

### DIFF
--- a/src/fp.c
+++ b/src/fp.c
@@ -321,7 +321,9 @@ void fpUpdateCheats(void) {
         }
     }
     if (CHEAT_ACTIVE(CHEAT_AUTO_ACTION_CMD)) {
-        pm_gActionCommandStatus.autoSucceed = 1;
+        // prevent tidal wave crash
+        pm_gActionCommandStatus.autoSucceed =
+            pm_gActionCommandStatus.actionCommandID != 23 || pm_gActionCommandStatus.unk_5D < 14;
     }
     if (CHEAT_ACTIVE(CHEAT_BRIGHTEN_ROOM)) {
         pm_set_screen_overlay_alpha(1, 0);


### PR DESCRIPTION
Addresses #86. Technically you can still crash if you press the last input manually, but this is such a niche case that that's on the user at that point lmao.