### PR TITLE
Accommodate glankk/n64 changes

### DIFF
--- a/genhooks
+++ b/genhooks
@@ -6,8 +6,13 @@ if [ -z "$elf" ]; then
 	exit
 fi
 
+mips="$2"
+if [ -z "$mips" ]; then
+  mips="mips64"
+fi
+
 symtbl="$(mktemp)"
-mips64-nm "$elf" | awk '(/^[0-9A-Za-z_ ]*$/) {printf "sym_%s=0x%s\n",$3,substr($1,length($1)-7)}' >"$symtbl"
+$mips-nm "$elf" | awk '(/^[0-9A-Za-z_ ]*$/) {printf "sym_%s=0x%s\n",$3,substr($1,length($1)-7)}' >"$symtbl"
 . "$symtbl"
 rm -f "$symtbl"
 
@@ -24,8 +29,8 @@ genhook()
 {
     addr="$(printf "%d" "$1")"
     tmp="$(mktemp)"
-    echo ".set noreorder; .set noat; $2" | mips64-as - -o "$tmp"
-    mips64-readelf -x .text "$tmp" | grep "0x[0-9A-Fa-f]\{8\}" | grep -o " [0-9A-Fa-f]\{8\}" |
+    echo ".set noreorder; .set noat; $2" | $mips-as - -o "$tmp"
+    $mips-readelf -x .text "$tmp" | grep "0x[0-9A-Fa-f]\{8\}" | grep -o " [0-9A-Fa-f]\{8\}" |
     while read -r line; do
         gsc16 "$addr" "0x`echo "$line" | sed -e "s/\(....\)..../\1/"`"
         addr="$(expr "$addr" + 2)"

--- a/src/fp/debug/flags.c
+++ b/src/fp/debug/flags.c
@@ -60,7 +60,8 @@ static void addEvent(s32 recordIndex, s32 flagIndex, bool value) {
     e->recordIndex = recordIndex;
     e->flagIndex = flagIndex;
     e->value = value;
-    snprintf(e->description, sizeof(e->description), "%s[0x%0*lx] := %i", r->name, r->indexLength, flagIndex, value);
+    snprintf(e->description, sizeof(e->description), "%s[0x%0*lx] := %i", r->name, r->indexLength % 10, flagIndex,
+             value);
 }
 
 static u32 getFlagWord(void *data, size_t wordSize, s32 index) {


### PR DESCRIPTION
glankk's n64 toolchain now appears to use commands that start with `mips64-ultra-elf` instead of `mips64`. This updates fp to dynamically use whichever is installed.