### PR TITLE
Fix typo in warp_info.h for 'sand switch 3'

### DIFF
--- a/src/fp/warps/warp_info.h
+++ b/src/fp/warps/warp_info.h
@@ -270,7 +270,7 @@ struct AreaInfo areaDryDryRuins = {
         {"super hammer", 0x1},
         {"super block", 0x3},
         {"stone pedestals", 0x4},
-        {"sand swtich 3", 0x4},
+        {"sand switch 3", 0x4},
         {"lunar stone", 0x1},
         {"diamond stone", 0x1},
         {"tutankoopa", 0x1},


### PR DESCRIPTION
Good day,

I saw this typo, I thought I'd take the opportunity to fix it. Thanks for the great work!